### PR TITLE
Add CMV computation by mapping CMV[i] to the corresponding LICi result with correct parameters. Fix #12

### DIFF
--- a/app/src/main/java/org/example/CMV.java
+++ b/app/src/main/java/org/example/CMV.java
@@ -6,21 +6,21 @@ public class CMV {
     public static Boolean[] computeCMV(Point[] points, Parameters parameters) {
         Boolean[] cmv = new Boolean[15];
 
-        cmv[0] = lic0();
-        cmv[1] = lic1();
-        cmv[2] = lic2();
-        cmv[3] = lic3();
-        cmv[4] = lic4();
-        cmv[5] = lic5();
-        cmv[6] = lic6();
-        cmv[7] = lic7();
-        cmv[8] = lic8();
-        cmv[9] = lic9();
-        cmv[10] = lic10();
-        cmv[11] = lic11();
-        cmv[12] = lic12();
-        cmv[13] = lic13();
-        cmv[14] = lic14();
+        cmv[0] = lic0(points, parameters.LENGTH1);
+        cmv[1] = lic1(points, parameters.RADIUS1);
+        cmv[2] = lic2(points, parameters.EPSILON);
+        cmv[3] = lic3(points, parameters.AREA1);
+        cmv[4] = lic4(points, parameters.Q_PTS, parameters.QUADS);
+        cmv[5] = lic5(points);
+        cmv[6] = lic6(points, parameters.N_PTS, parameters.DIST);
+        cmv[7] = lic7(points, parameters.K_PTS, parameters.LENGTH1);
+        cmv[8] = lic8(points, parameters.A_PTS, parameters.B_PTS, parameters.RADIUS1);
+        cmv[9] = lic9(points, parameters.C_PTS, parameters.D_PTS, parameters.EPSILON);
+        cmv[10] = lic10(points, parameters.E_PTS, parameters.F_PTS, parameters.AREA1);
+        cmv[11] = lic11(points, parameters.G_PTS);
+        cmv[12] = lic12(points, parameters.K_PTS, parameters.LENGTH1, parameters.LENGTH2);
+        cmv[13] = lic13(points, parameters.A_PTS, parameters.B_PTS, parameters.RADIUS1, parameters.RADIUS2);
+        cmv[14] = lic14(points, parameters.E_PTS, parameters.F_PTS, parameters.AREA1, parameters.AREA2);
 
         return cmv;
     }


### PR DESCRIPTION
Added only the parameters for each function call. Maybe add tests also? But at the same time, all LICs are covered by their own tests, and all are called independently with the CMV[i] being of fixed length (15). 